### PR TITLE
fixed repository handling

### DIFF
--- a/PSFramework.NuGet/PSFramework.NuGet.psd1
+++ b/PSFramework.NuGet/PSFramework.NuGet.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'PSFramework.NuGet.psm1'
 	
 	# Version number of this module.
-	ModuleVersion     = '0.9.0'
+	ModuleVersion     = '0.9.2'
 	
 	# ID used to uniquely identify this module
 	GUID              = 'ad0f2a25-552f-4dd6-bd8e-5ddced2a5d88'

--- a/PSFramework.NuGet/changelog.md
+++ b/PSFramework.NuGet/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 0.9.2 (2025-01-17)
+
++ Fix: Get-PSFRepository - writes error when searching for a specific repository that only exists in one PSGet version
++ Fix: Update-PSFRepository - will update the "Trusted" status of a configured repository, even if the base properties have not yet been configured
+
 ## 0.9.0 (2025-01-03)
 
 + Initial Preview Release

--- a/PSFramework.NuGet/functions/Repository/Get-PSFRepository.ps1
+++ b/PSFramework.NuGet/functions/Repository/Get-PSFRepository.ps1
@@ -44,7 +44,8 @@
 	}
 	process {
 		if ($script:psget.V3 -and $Type -in 'All','V3') {
-			foreach ($repository in Get-PSResourceRepository -Name $Name) {
+			foreach ($repository in Get-PSResourceRepository -Name $Name -ErrorAction Ignore) {
+				if (-not $repository) [ continue ]
 				[PSCustomObject]@{
 					PSTypeName = 'PSFramework.NuGet.Repository'
 					Name       = $repository.Name
@@ -63,7 +64,8 @@
 			if (-not $script:psget.v2CanPublish) { $status = 'NoPublish' }
 			if (-not $script:psget.v2CanInstall) { $status = 'NoInstall' }
 
-			foreach ($repository in Get-PSRepository -Name $Name) {
+			foreach ($repository in Get-PSRepository -Name $Name -ErrorAction Ignore) {
+				if (-not $repository) [ continue ]
 				[PSCustomObject]@{
 					PSTypeName = 'PSFramework.NuGet.Repository'
 					Name       = $repository.Name

--- a/PSFramework.NuGet/functions/Repository/Get-PSFRepository.ps1
+++ b/PSFramework.NuGet/functions/Repository/Get-PSFRepository.ps1
@@ -45,7 +45,7 @@
 	process {
 		if ($script:psget.V3 -and $Type -in 'All','V3') {
 			foreach ($repository in Get-PSResourceRepository -Name $Name -ErrorAction Ignore) {
-				if (-not $repository) [ continue ]
+				if (-not $repository) { continue }
 				[PSCustomObject]@{
 					PSTypeName = 'PSFramework.NuGet.Repository'
 					Name       = $repository.Name
@@ -65,7 +65,7 @@
 			if (-not $script:psget.v2CanInstall) { $status = 'NoInstall' }
 
 			foreach ($repository in Get-PSRepository -Name $Name -ErrorAction Ignore) {
-				if (-not $repository) [ continue ]
+				if (-not $repository) { continue }
 				[PSCustomObject]@{
 					PSTypeName = 'PSFramework.NuGet.Repository'
 					Name       = $repository.Name


### PR DESCRIPTION
+ Fix: Get-PSFRepository - writes error when searching for a specific repository that only exists in one PSGet version
+ Fix: Update-PSFRepository - will update the "Trusted" status of a configured repository, even if the base properties have not yet been configured