### PR TITLE
0.9.12

### DIFF
--- a/PSFramework.NuGet/PSFramework.NuGet.psd1
+++ b/PSFramework.NuGet/PSFramework.NuGet.psd1
@@ -3,7 +3,7 @@
 	RootModule        = 'PSFramework.NuGet.psm1'
 	
 	# Version number of this module.
-	ModuleVersion     = '0.9.11'
+	ModuleVersion     = '0.9.12'
 	
 	# ID used to uniquely identify this module
 	GUID              = 'ad0f2a25-552f-4dd6-bd8e-5ddced2a5d88'

--- a/PSFramework.NuGet/changelog.md
+++ b/PSFramework.NuGet/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## ???
+
++ Fix: Install-PSFModule - fails to install on a default Windows PowerShell console without any modifications.
+
 ## 0.9.11 (2025-05-05)
 
 + New: Bootstrap script to deploy PSFramework.NuGet to the local computer without requiring Package Management.

--- a/PSFramework.NuGet/changelog.md
+++ b/PSFramework.NuGet/changelog.md
@@ -1,6 +1,6 @@
 ﻿# Changelog
 
-## ???
+## 0.9.12 (2025-05-06)
 
 + Fix: Install-PSFModule - fails to install on a default Windows PowerShell console without any modifications.
 

--- a/PSFramework.NuGet/internal/functions/Get/Save-StagingModule.ps1
+++ b/PSFramework.NuGet/internal/functions/Get/Save-StagingModule.ps1
@@ -115,8 +115,10 @@
 
 			$tempDirectory = New-PSFTempDirectory -Name StagingSub -ModuleName PSFramework.NuGet
 			$param = $Item.v2Param
+			$actualParam = $param + $callSpecifics | ConvertTo-PSFHashtable -ReferenceCommand Save-Module
+
 			# 1) Save to temp folder
-			try { Save-Module @param -Path $tempDirectory @callSpecifics }
+			try { Save-Module @actualParam -Path $tempDirectory }
 			catch {
 				Write-PSFMessage -String 'Save-StagingModule.SavingV2.Error.Download' -StringValues $Item.Name, $Item.Version, $Repository.Name, $Repository.Type -Target $Item -Tag fail, save -ErrorRecord $_
 				$result.Error = $_

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ To install this module, run ...
 Install-Module PSFramework.NuGet -Scope CurrentUser
 ```
 
+Of course, problem here is that if you want to use this module, this very line might be failing already!
+So, here is a way to bootstrap your current console without requiring PowerShellGet to already function:
+
+```powershell
+iwr https://raw.githubusercontent.com/PowershellFrameworkCollective/PSFramework.NuGet/refs/heads/master/bootstrap.ps1 | iex
+```
+
 ## Features
 
 ### Module Installation (Local or Remote)

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 	Installs all that is needed to run PSFramework.NuGet without using the PowerShellGet tools.
 


### PR DESCRIPTION
+ Fix: Install-PSFModule - fails to install on a default Windows PowerShell console without any modifications.